### PR TITLE
Fix: rename packets based on latest naming schema

### DIFF
--- a/game_coordinator/application/coordinator.py
+++ b/game_coordinator/application/coordinator.py
@@ -51,7 +51,7 @@ class Application:
         asyncio.create_task(self._servers[server_id].disconnect())
         del self._servers[server_id]
 
-    async def receive_PACKET_COORDINATOR_CLIENT_REGISTER(self, source, protocol_version, game_type, server_port):
+    async def receive_PACKET_COORDINATOR_SERVER_REGISTER(self, source, protocol_version, game_type, server_port):
         if isinstance(source.ip, ipaddress.IPv6Address):
             server_id_str = f"[{source.ip}]:{server_port}"
         else:
@@ -63,7 +63,7 @@ class Application:
         self._servers[source.server.server_id] = source.server
         await source.server.detect_connection()
 
-    async def receive_PACKET_COORDINATOR_CLIENT_UPDATE(self, source, protocol_version, **info):
+    async def receive_PACKET_COORDINATOR_SERVER_UPDATE(self, source, protocol_version, **info):
         await source.server.update(info)
 
     async def receive_PACKET_COORDINATOR_CLIENT_LISTING(
@@ -82,4 +82,4 @@ class Application:
             else:
                 servers_other.append(server)
 
-        await source.protocol.send_PACKET_COORDINATOR_SERVER_LISTING(game_info_version, servers_match + servers_other)
+        await source.protocol.send_PACKET_COORDINATOR_GC_LISTING(game_info_version, servers_match + servers_other)

--- a/game_coordinator/application/helpers/server.py
+++ b/game_coordinator/application/helpers/server.py
@@ -91,5 +91,5 @@ class Server:
         except (OSError, ConnectionRefusedError, asyncio.TimeoutError):
             pass
 
-        await self._source.protocol.send_PACKET_COORDINATOR_SERVER_REGISTER_ACK(connection_type=self.connection_type)
+        await self._source.protocol.send_PACKET_COORDINATOR_GC_REGISTER_ACK(connection_type=self.connection_type)
         self._task = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.0.1
 idna==3.2
 multidict==5.1.0
 openttd-helpers==1.0.1
-openttd-protocol==0.1.3
+openttd-protocol==0.2.0
 sentry-sdk==1.1.0
 typing-extensions==3.10.0.0
 urllib3==1.26.6


### PR DESCRIPTION
This schema makes it a bit more clear what the direction of
packets is.