### PR TITLE
Feature: SOCKS proxy support for new connections

### DIFF
--- a/game_coordinator/__main__.py
+++ b/game_coordinator/__main__.py
@@ -50,14 +50,18 @@ async def run_server(application, bind, port, ProtocolClass):
     "(HINT: for nginx, configure proxy_requests to 1).",
     is_flag=True,
 )
+@click.option(
+    "--socks-proxy",
+    help="Use a SOCKS proxy to query game servers.",
+)
 @click_database_redis
-def main(bind, coordinator_port, web_port, db, proxy_protocol):
+def main(bind, coordinator_port, web_port, db, proxy_protocol, socks_proxy):
     loop = asyncio.get_event_loop()
 
     db_instance = db()
     loop.run_until_complete(db_instance.startup())
 
-    app_instance = CoordinatorApplication(db_instance)
+    app_instance = CoordinatorApplication(db_instance, socks_proxy)
 
     CoordinatorProtocol.proxy_protocol = proxy_protocol
 

--- a/game_coordinator/application/coordinator.py
+++ b/game_coordinator/application/coordinator.py
@@ -14,8 +14,9 @@ log = logging.getLogger(__name__)
 
 
 class Application:
-    def __init__(self, database):
+    def __init__(self, database, socks_proxy):
         self.database = database
+        self.socks_proxy = socks_proxy
         self._servers = {}
 
         self.database.application = self

--- a/requirements.base
+++ b/requirements.base
@@ -4,3 +4,4 @@ click
 sentry-sdk
 openttd-helpers
 openttd-protocol
+pproxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,12 @@ attrs==21.2.0
 certifi==2021.5.30
 chardet==4.0.0
 click==8.0.1
+hiredis==2.0.0
 idna==3.2
 multidict==5.1.0
 openttd-helpers==1.0.1
 openttd-protocol==0.2.0
+pproxy==2.7.8
 sentry-sdk==1.1.0
 typing-extensions==3.10.0.0
 urllib3==1.26.6


### PR DESCRIPTION
This is mostly needed to run on AWS, as the containers run in an
isolated subnet, and cannot talk to the Internet. They need a
SOCKS proxy to bounce the new connection.

We use the pproxy client (and server) to make this happen.