### PR TITLE
Feature: collect very basic statistics about Coordinator usage

### DIFF
--- a/game_coordinator/__main__.py
+++ b/game_coordinator/__main__.py
@@ -84,7 +84,7 @@ def main(bind, app, coordinator_port, stun_port, web_port, shared_secret, db, pr
     server = loop.run_until_complete(run_server(app_instance, bind, port, protocol))
 
     try:
-        start_webserver(bind, web_port)
+        start_webserver(bind, web_port, db_instance)
     except KeyboardInterrupt:
         pass
 

--- a/game_coordinator/application/helpers/token_verify.py
+++ b/game_coordinator/application/helpers/token_verify.py
@@ -67,6 +67,9 @@ class TokenVerify:
             server_ip_str = f"[{server_ip}]" if isinstance(server_ip, ipaddress.IPv6Address) else str(server_ip)
             self._server.direct_ips.append({"ip": server_ip_str, "port": self._server.server_port})
             await self._application.database.direct_ip(self._server.server_id, server_ip, self._server.server_port)
+
+            ip_type = "ipv6" if isinstance(server_ip, ipaddress.IPv6Address) else "ipv4"
+            await self._application.database.stats_verify(f"direct-{ip_type}")
         except (OSError, ConnectionRefusedError, asyncio.TimeoutError):
             # These all indicate a connection could not be created, so the server is not reachable.
             pass
@@ -89,6 +92,9 @@ class TokenVerify:
             )
 
         await self._server.send_register_ack(self._protocol_version)
+        await self._application.database.stats_verify(
+            self._server.connection_type.name[len("CONNECTION_TYPE_") :].lower()
+        )
 
     async def _create_connection(self, server_ip, server_port):
         connected = asyncio.Event()


### PR DESCRIPTION
We collect, with the resolution of a day, per connection-method
(direct-ip, STUN, ..), the following:
- How many servers registered with this connection-method
- How many connects failed with a connection-method
- How many connects succeeded with a connection-method

This to give us a bit of insight how often STUN actually works,
and how many servers allow direct-ip connections.

---

To be crystal clear, no user-information is collected, nor information that in any way can lead back to any individual. This merely collects very basic usage statistics of the service itself, not of its users. This with as goal to understand the effectiveness of STUN in OpenTTD.