### PR TITLE
Fix: gc-stream wasn't given a limit correctly, causing it to grow infinite

### DIFF
--- a/game_coordinator/database/redis.py
+++ b/game_coordinator/database/redis.py
@@ -168,7 +168,7 @@ class Database:
 
     async def add_to_stream(self, entry_type, payload):
         await self._redis.xadd(
-            "gc-stream", {"gc-id": self._gc_id, "type": entry_type, "payload": json.dumps(payload)}, approximate=1000
+            "gc-stream", {"gc-id": self._gc_id, "type": entry_type, "payload": json.dumps(payload)}, maxlen=1000
         )
 
     async def update_info(self, server_id, info):


### PR DESCRIPTION
Well, in the end, the Redis OOM kicked in. But .. yeah ..