### PR TITLE
Feature: reduce bandwidth needed to serve clients the serverlist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ hiredis==2.0.0
 idna==3.2
 multidict==5.1.0
 openttd-helpers==1.0.1
-openttd-protocol==0.4.1
+openttd-protocol==0.5.0
 pproxy==2.7.8
 sentry-sdk==1.1.0
 typing-extensions==3.10.0.0


### PR DESCRIPTION
Game Coordinator protocol 4 allows us to send the client a table
of NewGRFs, and after that use an index into that table for each
server. This heavily reduces the size of the full serverlist, from
~60KB to ~20KB.
Additionally, we now also send the name of the NewGRF to the client.
In case the client doesn't have the NewGRF yet, it can now show
the name of the NewGRF instead of the grfid or md5sum.

Further more, this reduces the load on redis, as we only update
NewGRFs when there is something to update, instead of every 30
seconds. NewGRFs in multiplayer games can only change when starting
a newgame, and never during a game.