### PR TITLE
Change: give TURN more time to connect (from 10 to 20 seconds)

### DIFF
--- a/game_coordinator/application/helpers/token_connect.py
+++ b/game_coordinator/application/helpers/token_connect.py
@@ -6,6 +6,8 @@ from openttd_protocol.wire.exceptions import SocketClosed
 
 log = logging.getLogger(__name__)
 
+TIMEOUT = 20  # After how many seconds we give up on connecting client and server.
+
 
 class TokenConnect:
     def __init__(self, application, source, protocol_version, token, server):
@@ -70,7 +72,7 @@ class TokenConnect:
 
     async def _timeout(self):
         try:
-            await asyncio.sleep(10)
+            await asyncio.sleep(TIMEOUT)
 
             # If we reach here, we haven't managed to get a connection within 10 seconds. Time to call it a day.
             self._timeout_task = None

--- a/game_coordinator/application/turn.py
+++ b/game_coordinator/application/turn.py
@@ -8,6 +8,7 @@ from openttd_helpers import click_helper
 log = logging.getLogger(__name__)
 
 TTL = 15
+TIMEOUT = 20  # After how many seconds we give up on connecting client and server.
 
 _turn_address = None
 
@@ -82,8 +83,12 @@ class Application:
         await self._ticket_pair[ticket].protocol.send_PACKET_TURN_TURN_CONNECTED(protocol_version, str(source.ip))
         await self.database.stats_turn("two-sided")
 
+        del self._ticket_pair[ticket]
+
     async def _expire_ticket(self, ticket):
-        await asyncio.sleep(10)
+        await asyncio.sleep(TIMEOUT)
+
+        self._ticket_pair[ticket].protocol.transport.close()
 
         # Expire the ticket after 10 seconds if there was no match.
         del self._ticket_pair[ticket]

--- a/game_coordinator/database/redis.py
+++ b/game_coordinator/database/redis.py
@@ -371,7 +371,7 @@ class Database:
         while True:
             ticket_left = secrets.token_hex(8)
             ticket_right = secrets.token_hex(8)
-            if await self._redis.set(f"turn-ticket:{ticket_left}", ticket_right, ex=10, nx=True):
+            if await self._redis.set(f"turn-ticket:{ticket_left}", ticket_right, ex=30, nx=True):
                 break
 
         return f"{ticket_left}:{ticket_right}"


### PR DESCRIPTION
This means that users that get a popup client-side to ask if they
want to use TURN have more time to read the dialog. On average this
should now be ~18 seconds that they have time to read it, up from
~8 seconds.