### PR TITLE
Fix: ensure direct-ips of servers are unique

### DIFF
--- a/game_coordinator/application/helpers/server.py
+++ b/game_coordinator/application/helpers/server.py
@@ -21,7 +21,7 @@ class ServerExternal:
         self.info = {}
         self.game_type = None
         self.server_id = server_id
-        self.direct_ips = []
+        self.direct_ips = set()
 
         if self.server_id[0] == "+":
             self.connection_string = self.server_id
@@ -53,7 +53,7 @@ class ServerExternal:
         if ip_type == "ipv6":
             ip = f"[{ip}]"
 
-        self.direct_ips.append({"ip": ip, "port": port})
+        self.direct_ips.add(f"{ip}:{port}")
         self.connection_type = ConnectionType.CONNECTION_TYPE_DIRECT
 
     async def send_stun_request(self, protocol_version, token):
@@ -83,7 +83,7 @@ class Server:
         self.game_type = game_type
         self.server_id = server_id
         self.server_port = server_port
-        self.direct_ips = []
+        self.direct_ips = set()
 
         if invite_code_secret:
             self.connection_string = server_id

--- a/game_coordinator/application/helpers/token_verify.py
+++ b/game_coordinator/application/helpers/token_verify.py
@@ -65,7 +65,7 @@ class TokenVerify:
 
             # Record the direct-ip in various of places.
             server_ip_str = f"[{server_ip}]" if isinstance(server_ip, ipaddress.IPv6Address) else str(server_ip)
-            self._server.direct_ips.append({"ip": server_ip_str, "port": self._server.server_port})
+            self._server.direct_ips.add(f"{server_ip_str}:{self._server.server_port}")
             await self._application.database.direct_ip(self._server.server_id, server_ip, self._server.server_port)
 
             ip_type = "ipv6" if isinstance(server_ip, ipaddress.IPv6Address) else "ipv4"


### PR DESCRIPTION
The master-server was resending the same direct-ip every time,
which meant the memory of the Game Coordinator kept increasing
more and more.