### PR TITLE
Fix: multiple servers announcing themselves with the same invite-code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ hiredis==2.0.0
 idna==3.2
 multidict==5.1.0
 openttd-helpers==1.0.1
-openttd-protocol==1.0.0
+openttd-protocol==1.1.0
 pproxy==2.7.8
 sentry-sdk==1.1.0
 typing-extensions==3.10.0.0


### PR DESCRIPTION
A user can be silly and use the same configuration for two servers
on different ports.
To deal with the situation, disconnect the old server and use the
new server. Most likely the old server reconnects, kicks off the
new server, and this battle continues till the user realises
what is going on.
Not much more we can do about it.