### PR TITLE
Fix: track better why a connection (method) failed

### DIFF
--- a/game_coordinator/database/redis.py
+++ b/game_coordinator/database/redis.py
@@ -327,8 +327,14 @@ class Database:
     async def stats_verify(self, connection_type_name):
         await self._stats("verify", connection_type_name)
 
-    async def stats_connect(self, method_name, result):
-        key = "connect" if result else "connect-failed"
+    async def stats_connect(self, method_name, result, final=True):
+        if result:
+            # Successful connections are always final.
+            key = "connect"
+        elif final:
+            key = "connect-failed"
+        else:
+            key = "connect-method-failed"
 
         await self._stats(key, method_name)
 

--- a/game_coordinator/web.py
+++ b/game_coordinator/web.py
@@ -22,6 +22,7 @@ async def stats_handler(request):
             "listing": await DB_INSTANCE.get_stats("listing"),
             "connect": await DB_INSTANCE.get_stats("connect"),
             "connect-failed": await DB_INSTANCE.get_stats("connect-failed"),
+            "connect-method-failed": await DB_INSTANCE.get_stats("connect-method-failed"),
             "turn": await DB_INSTANCE.get_stats("turn"),
         }
     )


### PR DESCRIPTION
Also make it more obvious what is a final call, and what is a
"this method failed".