### PR TITLE
Fix: conclude server-probe earlier if all results are in

### DIFF
--- a/game_coordinator/application/coordinator.py
+++ b/game_coordinator/application/coordinator.py
@@ -311,11 +311,12 @@ class Application:
     async def receive_PACKET_COORDINATOR_SERCLI_STUN_RESULT(
         self, source, protocol_version, token, interface_number, result
     ):
-        # This informs us that the client has did his STUN request. We
-        # currently take no action on this packet, but it could be used to
-        # know there should be a STUN result or to continue with the next
-        # available method.
-        pass
+        token = self._tokens.get(token[1:])
+        if token is None:
+            # Don't close connection, as this might just be a delayed result.
+            return
+
+        await token.stun_result_concluded(interface_number, result)
 
 
 @click_helper.extend

--- a/game_coordinator/application/helpers/token_connect.py
+++ b/game_coordinator/application/helpers/token_connect.py
@@ -76,6 +76,10 @@ class TokenConnect:
                     (f"stun-{ip_type}", lambda: self._connect_stun_connect(client_peer, server_peer))
                 )
 
+    async def stun_result_concluded(self, interface_number, result):
+        # Not yet used.
+        pass
+
     async def _timeout(self):
         try:
             await asyncio.sleep(TIMEOUT)


### PR DESCRIPTION
Additionally, change the direct-ip-detection timeout to three
seconds instead of one, to give servers more time to respond.

Before this PR, server-probe always took 2-seconds, no matter what type of server you had. But we had enough information to conclude a lot earlier in many situations.

Additionally, we only wait 1 seconds for direct-ip-detection to conclude, which is rather tight. OpenTTD itself gives connections 3 seconds, so we should do the same.

In result, with this PR:
- Direct-ip servers get a conclusion within a second
- STUN servers have to wait ~3 seconds (wait for the STUN result + 3 seconds for the direct-ip-detection to time out)
- If STUN fails, it continues as soon as the above two conclude

As fallback, in case we have a bug or what-ever in the above, after 7 seconds it concludes no matter what. This really is just a safe-guard.