### PR TITLE
Codechange: rework how connections are setup

### DIFF
--- a/game_coordinator/application/coordinator.py
+++ b/game_coordinator/application/coordinator.py
@@ -311,12 +311,13 @@ class Application:
     async def receive_PACKET_COORDINATOR_SERCLI_STUN_RESULT(
         self, source, protocol_version, token, interface_number, result
     ):
+        prefix = token[0]
         token = self._tokens.get(token[1:])
         if token is None:
             # Don't close connection, as this might just be a delayed result.
             return
 
-        await token.stun_result_concluded(interface_number, result)
+        await token.stun_result_concluded(prefix, interface_number, result)
 
 
 @click_helper.extend

--- a/game_coordinator/application/helpers/token_connect.py
+++ b/game_coordinator/application/helpers/token_connect.py
@@ -21,34 +21,26 @@ class TokenConnect:
         self.client_token = f"C{self.token}"
         self.server_token = f"S{self.token}"
 
-        self._stun_result = {
-            "C": {},
-            "S": {},
-        }
-
     async def connect(self):
         self._tracking_number = 1
-
-        # Create a queue with methods we have to connect the client and the
-        # server. As some methods (like STUN) are dynamic, a task will be
-        # reading this queue for a few seconds, awaiting other methods if
-        # needed.
-        self._connect_methods = asyncio.Queue()
-        for direct_ip in self._server.direct_ips:
-            server_ip, _, server_port = direct_ip.rpartition(":")
-            ip_type = "ipv6" if server_ip.startswith("[") else "ipv4"
-            self._connect_methods.put_nowait(
-                (f"direct-{ip_type}", lambda: self._connect_direct_connect(server_ip, int(server_port)))
-            )
-        self._connect_methods.put_nowait(("stun-request", lambda: self._connect_stun_request()))
+        self._connect_result_event = asyncio.Event()
 
         # The peer-type of STUN requests we allow to match.
         self._stun_ip_type = [
             "ipv4",
             "ipv6",
         ]
+        self._stun_result = {
+            "C": {},
+            "S": {},
+        }
+        self._stun_result_seen = {
+            "C": set(),
+            "S": set(),
+        }
+        self._stun_pairs = asyncio.Queue()
 
-        self._connect_task = asyncio.create_task(self._connect())
+        self._connect_task = asyncio.create_task(self._connect_guard())
         self._timeout_task = asyncio.create_task(self._timeout())
 
     async def connected(self):
@@ -59,84 +51,12 @@ class TokenConnect:
 
         await self._application.database.stats_connect(self._connect_method, True)
 
-    async def stun_result(self, prefix, interface_number, peer_type, peer_ip, peer_port):
-        if peer_type == "ipv6":
-            peer_ip = f"[{peer_ip}]"
-
-        self._stun_result[prefix][peer_type] = (interface_number, peer_ip, peer_port)
-
-        for ip_type in self._stun_ip_type:
-            if ip_type in self._stun_result["C"] and ip_type in self._stun_result["S"]:
-                self._stun_ip_type.remove(ip_type)
-
-                client_peer = self._stun_result["C"][ip_type]
-                server_peer = self._stun_result["S"][ip_type]
-
-                self._connect_methods.put_nowait(
-                    (f"stun-{ip_type}", lambda: self._connect_stun_connect(client_peer, server_peer))
-                )
-
-    async def stun_result_concluded(self, interface_number, result):
-        # Not yet used.
-        pass
-
-    async def _timeout(self):
-        try:
-            await asyncio.sleep(TIMEOUT)
-
-            # If we reach here, we haven't managed to get a connection within TIMEOUT seconds. Time to call it a day.
-            self._timeout_task = None
-            await self._connect_failed("timeout")
-        except Exception:
-            log.exception("Exception during _timeout()")
-
-    async def _connect(self):
-        self._connect_next_event = asyncio.Event()
-
-        while True:
-            try:
-                await asyncio.wait_for(self._connect_next_wait(), 2)
-            except asyncio.TimeoutError:
-                # It took more than 2 seconds to get a new method for
-                # connecting. At this point it is safe to assume there will
-                # not be any other methods presenting itself. As a last-resort,
-                # try if TURN is available.
-                if self._protocol_version >= 5 and self._application.turn_servers:
-                    connection_string = random.choice(self._application.turn_servers)
-
-                    # If no STUN request was received, this signal is still set.
-                    self._connect_next_event.clear()
-
-                    self._tracking_number += 1
-                    self._connect_method = "turn"
-                    await self._connect_turn_connect(connection_string)
-                    await self._connect_next_event.wait()
-
-                    # If TURN failed, we have no other method left, so fail the attempt.
-
-                self._connect_task = None
-                asyncio.create_task(self._connect_failed("out-of-methods"))
-                break
-            except SocketClosed:
-                # Either of the two sides closed the Game Coordinator
-                # connection. So cancel the connection attempt.
-                self._connect_task = None
-                asyncio.create_task(self._connect_failed("closed"))
-                break
-            except Exception:
-                log.exception("Exception during _connect_next_wait()")
-
-            await self._connect_next_event.wait()
-
-    async def _connect_next_wait(self):
-        (name, proc) = await self._connect_methods.get()
-        self._connect_method = name
-        await proc()
-
     async def connect_failed(self, tracking_number):
         if tracking_number == 0:
             # Client requested we stop with this connection attempt. So clean it up!
-            asyncio.create_task(self._connect_failed("stop"))
+            asyncio.create_task(self._connect_give_up("stop"))
+            # Make sure any late-arrivers for the current attempt are not counted.
+            self._tracking_number = -1
             return
 
         # Check if this is our current attempt. Server and client send
@@ -149,9 +69,89 @@ class TokenConnect:
 
         # Try the next attempt now.
         self._tracking_number += 1
-        self._connect_next_event.set()
+        self._connect_result_event.set()
+
+    async def stun_result(self, prefix, interface_number, peer_type, peer_ip, peer_port):
+        if peer_type == "ipv6":
+            peer_ip = f"[{peer_ip}]"
+
+        self._stun_result[prefix][peer_type] = (interface_number, peer_ip, peer_port)
+
+        for ip_type in self._stun_ip_type:
+            if ip_type in self._stun_result["C"] and ip_type in self._stun_result["S"]:
+                self._stun_ip_type.remove(ip_type)
+                self._stun_pairs.put_nowait(ip_type)
+
+        self._stun_result_seen[prefix].add(interface_number)
+        if len(self._stun_result_seen["C"]) == 2 and len(self._stun_result_seen["S"]) == 2:
+            # Both sides reported all their STUN results. Inform _connect().
+            self._stun_pairs.put_nowait(None)
+
+    async def stun_result_concluded(self, prefix, interface_number, result):
+        if result:
+            # Successful STUN results will call stun_result() eventually too.
+            return
+
+        self._stun_result_seen[prefix].add(interface_number)
+        if len(self._stun_result_seen["C"]) == 2 and len(self._stun_result_seen["S"]) == 2:
+            # Both sides reported all their STUN results. Inform _connect().
+            self._stun_pairs.put_nowait(None)
+
+    async def _timeout(self):
+        try:
+            await asyncio.sleep(TIMEOUT)
+
+            # If we reach here, we haven't managed to get a connection within TIMEOUT seconds. Time to call it a day.
+            self._timeout_task = None
+            await self._connect_give_up("timeout")
+        except Exception:
+            log.exception("Exception during _timeout()")
+
+    async def _connect_guard(self):
+        try:
+            await self._connect()
+        except SocketClosed:
+            # Either of the two sides closed the Game Coordinator
+            # connection. So cancel the connection attempt.
+            asyncio.create_task(self._connect_give_up("closed"))
+        except Exception:
+            log.exception("Exception during _connect()")
+            asyncio.create_task(self._connect_give_up("exception"))
+
+        self._connect_task = None
+
+    async def _connect(self):
+        # Try connecting via direct-IPs first.
+        for direct_ip in self._server.direct_ips:
+            server_ip, _, server_port = direct_ip.rpartition(":")
+
+            await self._connect_direct_connect(server_ip, int(server_port))
+            await self._connect_result_event.wait()
+
+        # Send out STUN requests.
+        await self._connect_stun_request()
+
+        # Wait for STUN pairs to arrive.
+        while True:
+            ip_type = await self._stun_pairs.get()
+            if ip_type is None:
+                # We are being told no further STUN pairs will arrive.
+                break
+
+            await self._connect_stun_connect(ip_type)
+            await self._connect_result_event.wait()
+
+        # If all of the above fails, try TURN.
+        await self._connect_turn_connect()
+        await self._connect_result_event.wait()
+
+        # There are no more methods.
+        asyncio.create_task(self._connect_give_up("out-of-methods"))
 
     async def _connect_direct_connect(self, server_ip, server_port):
+        ip_type = "ipv6" if server_ip.startswith("[") else "ipv4"
+        self._connect_method = f"direct-{ip_type}"
+
         await self._source.protocol.send_PACKET_COORDINATOR_GC_DIRECT_CONNECT(
             self._protocol_version, self.client_token, self._tracking_number, server_ip, server_port
         )
@@ -160,12 +160,12 @@ class TokenConnect:
         await self._source.protocol.send_PACKET_COORDINATOR_GC_STUN_REQUEST(self._protocol_version, self.client_token)
         await self._server.send_stun_request(self._protocol_version, self.server_token)
 
-        # This is not really an attempt, but the STUN result will queue a new
-        # method to try when-ever it is ready. So already continue to the next
-        # iteration.
-        self._connect_next_event.set()
+    async def _connect_stun_connect(self, ip_type):
+        self._connect_method = f"stun-{ip_type}"
 
-    async def _connect_stun_connect(self, client_peer, server_peer):
+        client_peer = self._stun_result["C"][ip_type]
+        server_peer = self._stun_result["S"][ip_type]
+
         await self._source.protocol.send_PACKET_COORDINATOR_GC_STUN_CONNECT(
             self._protocol_version,
             self.client_token,
@@ -183,7 +183,15 @@ class TokenConnect:
             client_peer[2],
         )
 
-    async def _connect_turn_connect(self, connection_string):
+    async def _connect_turn_connect(self):
+        self._connect_method = "turn"
+
+        if self._protocol_version < 5 or not self._application.turn_servers:
+            await self.connect_failed(self._tracking_number)
+            return
+
+        connection_string = random.choice(self._application.turn_servers)
+
         turn_ticket = await self._application.database.create_turn_ticket()
 
         await self._source.protocol.send_PACKET_COORDINATOR_GC_TURN_CONNECT(
@@ -201,7 +209,7 @@ class TokenConnect:
             connection_string,
         )
 
-    async def _connect_failed(self, stats_type):
+    async def _connect_give_up(self, failure_reason):
         if self._connect_task:
             self._connect_task.cancel()
             self._connect_task = None
@@ -223,6 +231,6 @@ class TokenConnect:
             # If the server already left, that is fine.
             pass
 
-        await self._application.database.stats_connect(stats_type, False)
+        await self._application.database.stats_connect(failure_reason, False)
 
         self._application.delete_token(self.token)

--- a/game_coordinator/application/helpers/token_verify.py
+++ b/game_coordinator/application/helpers/token_verify.py
@@ -65,7 +65,7 @@ class TokenVerify:
         task = asyncio.create_task(self._start_detection(interface_number, peer_ip))
         self._pending_detection_tasks.append(task)
 
-    async def stun_result_concluded(self, interface_number, result):
+    async def stun_result_concluded(self, prefix, interface_number, result):
         if result:
             # Successful STUN results will call stun_result() eventually too.
             return


### PR DESCRIPTION
Instead of using a magic queue and wait for connection methods
to arrive on it, make a bit more use of coroutines and just write
in a single functions all the connection methods and their order.
This makes the whole function a lot less magic and more readable.

Accidental this might fix several issues, and report better
statistics about what is failing when.