### PR TITLE
Fix: one client could attempt multiple simultaneous connections to the same server

### DIFF
--- a/game_coordinator/application/helpers/client.py
+++ b/game_coordinator/application/helpers/client.py
@@ -1,0 +1,3 @@
+class Client:
+    def __init__(self):
+        self.connections = dict()

--- a/game_coordinator/application/helpers/token_connect.py
+++ b/game_coordinator/application/helpers/token_connect.py
@@ -21,6 +21,9 @@ class TokenConnect:
         self.client_token = f"C{self.token}"
         self.server_token = f"S{self.token}"
 
+    def delete_client_token(self):
+        del self._source.client.connections[self._server.server_id]
+
     async def connect(self):
         self._tracking_number = 1
         self._connect_result_event = asyncio.Event()
@@ -50,6 +53,9 @@ class TokenConnect:
         self._timeout_task = None
 
         await self._application.database.stats_connect(self._connect_method, True)
+
+    async def abort_attempt(self):
+        await self._connect_give_up("abort")
 
     async def connect_failed(self, tracking_number):
         if tracking_number == 0:


### PR DESCRIPTION
Although one could consider edge-cases where this can be useful
(refreshing a server while also joining it, for example), it also
allows for abuse. For example, if you hit Refresh like a maniac,
the client tries to establish many connections to the same server.

So instead of allowing this, simply drop all previous attempts
if the same client tries to connect to the exact same server.

The edge-case is not worth fixing, as if you join a server, the
refresh information is not useful to you anymore anyway.