### PR TITLE
Fix: crash if a server left during registration

### DIFF
--- a/game_coordinator/application/helpers/token_verify.py
+++ b/game_coordinator/application/helpers/token_verify.py
@@ -28,6 +28,11 @@ class DetectGame:
         # Inform caller that we have successful connected to the valid server.
         self._connected.set()
 
+    async def receive_PACKET_SERVER_SHUTDOWN(self, source):
+        source.protocol.transport.close()
+
+        # Let the timeout hit. It doesn't matter anyway.
+
 
 class TokenVerify:
     def __init__(self, application, source, protocol_version, token, server):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ hiredis==2.0.0
 idna==3.2
 multidict==5.1.0
 openttd-helpers==1.0.1
-openttd-protocol==1.1.1
+openttd-protocol==1.2.0
 pproxy==2.7.8
 sentry-sdk==1.1.0
 typing-extensions==3.10.0.0


### PR DESCRIPTION
This was because a server correctly fires a SERVER_SHUTDOWN packet,
but we didn't understand that packet and decided to crash instead.