### PR TITLE
Fix: if a server leaves while a client is connecting, abort the attempt

### DIFF
--- a/game_coordinator/application/helpers/token_connect.py
+++ b/game_coordinator/application/helpers/token_connect.py
@@ -54,8 +54,8 @@ class TokenConnect:
 
         await self._application.database.stats_connect(self._connect_method, True)
 
-    async def abort_attempt(self):
-        await self._connect_give_up("abort")
+    async def abort_attempt(self, reason):
+        await self._connect_give_up(f"abort-{reason}")
 
     async def connect_failed(self, tracking_number):
         if tracking_number == 0:


### PR DESCRIPTION
Although the chances of this happening are slim, it does feel a
lot better.

Additionally, make sure to clean up the verify-tokens, as they were
now causing a memory leak.