### PR TITLE
Fix: exception when a server leaves while a connect was just initiated

### DIFF
--- a/game_coordinator/application/helpers/token_connect.py
+++ b/game_coordinator/application/helpers/token_connect.py
@@ -21,6 +21,9 @@ class TokenConnect:
         self.client_token = f"C{self.token}"
         self.server_token = f"S{self.token}"
 
+        self._connect_task = None
+        self._timeout_task = None
+
     def delete_client_token(self):
         del self._source.client.connections[self._server.server_id]
 


### PR DESCRIPTION
If a server aborts in a very early stage, connect() has not been
called yet.