### PR TITLE
Add: implement graceful shutdown to clean up open sockets

### DIFF
--- a/game_coordinator/application/coordinator.py
+++ b/game_coordinator/application/coordinator.py
@@ -48,6 +48,12 @@ class Application:
     async def startup(self):
         await self.database.sync_and_monitor()
 
+    async def shutdown(self):
+        log.info("Shutting down Game Coordinator ...")
+
+        for server in self._servers.values():
+            server._source.protocol.transport.close()
+
     def disconnect(self, source):
         if hasattr(source, "server"):
             asyncio.create_task(self.remove_server(source.server.server_id))
@@ -195,7 +201,7 @@ class Application:
         for token in abort_tokens:
             await token.abort_attempt("server")
 
-        asyncio.create_task(self._servers[server_id].disconnect())
+        await self._servers[server_id].disconnect()
         del self._servers[server_id]
 
     async def gc_connect_failed(self, token, tracking_number):

--- a/game_coordinator/application/stun.py
+++ b/game_coordinator/application/stun.py
@@ -12,5 +12,8 @@ class Application:
     async def startup(self):
         pass
 
+    async def shutdown(self):
+        log.info("Shutting down STUN server ...")
+
     async def receive_PACKET_STUN_SERCLI_STUN(self, source, protocol_version, token, interface_number):
         await self.database.stun_result(token, interface_number, source.ip, source.port)

--- a/game_coordinator/web.py
+++ b/game_coordinator/web.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from aiohttp import web
@@ -49,4 +50,10 @@ def start_webserver(bind, web_port, db_instance):
     webapp = web.Application()
     webapp.add_routes(routes)
 
-    web.run_app(webapp, host=bind, port=web_port, access_log_class=ErrorOnlyAccessLogger)
+    # aiohttp normally takes over all kind of asyncio function, especially on
+    # shutdown. But we need to be in control of the shutdown to ensure it is
+    # done graceful. This means we need to call an internal aiohttp function
+    # to prevent the asyncio setup aiohttp normally does.
+    asyncio.ensure_future(
+        web._run_app(webapp, host=bind, port=web_port, access_log_class=ErrorOnlyAccessLogger, handle_signals=False)
+    )


### PR DESCRIPTION
This removes servers from the listing in case we are a GC server.
This updates the TURN usage statistics correctly when we are a TURN server.