### PR TITLE
Fix: only delete the client token if we are the owner

### DIFF
--- a/game_coordinator/application/helpers/token_connect.py
+++ b/game_coordinator/application/helpers/token_connect.py
@@ -26,7 +26,8 @@ class TokenConnect:
         self._given_up = False
 
     def delete_client_token(self):
-        del self._source.client.connections[self._server.server_id]
+        if self._source.client.connections[self._server.server_id] == self:
+            del self._source.client.connections[self._server.server_id]
 
     async def connect(self):
         self._tracking_number = 1


### PR DESCRIPTION
Due to concurrency, it can happen that a new token instance took
over the client for the given invite-code. In that case we should
not be deleting it.