### PR TITLE
Fix: old NewGRF entries were not removed from NewGRF lookup table

### DIFF
--- a/game_coordinator/database/redis.py
+++ b/game_coordinator/database/redis.py
@@ -117,7 +117,7 @@ class Database:
                         _, _, grfid_md5sum = message["data"].partition(":")
                         grfid, _, md5sum = grfid_md5sum.partition("-")
 
-                        await self.application.remove_newgrf_from_table(grfid, md5sum)
+                        await self.application.remove_newgrf_from_table(int(grfid), md5sum)
 
                     if message["data"].startswith("gc-server:"):
                         tracer.add_trace_field("command", "expire.gc-server")


### PR DESCRIPTION
Fixes #76

The field "grfid" in a NewGRF should be an integer. The expire event
sends it as string, but didn't convert it back to an integer. In result,
the expire routine failed to remove NewGRFs from the lookup table.

This means the table only grew, until the instance was reset again.