### PR TITLE
Add: use enable_strong_referenced_tasks() to prevent destroyed-while-pending

### DIFF
--- a/game_coordinator/__main__.py
+++ b/game_coordinator/__main__.py
@@ -4,6 +4,7 @@ import logging
 import signal
 
 from openttd_helpers import click_helper
+from openttd_helpers.asyncio_helper import enable_strong_referenced_tasks
 from openttd_helpers.logging_helper import click_logging
 from openttd_helpers.sentry_helper import click_sentry
 
@@ -104,7 +105,10 @@ def main(
     db,
     proxy_protocol,
 ):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    enable_strong_referenced_tasks(loop)
 
     db_instance = db()
     app_instance = app(db_instance)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ honeycomb-beeline==3.5.0
 idna==3.4
 libhoney==2.3.0
 multidict==6.0.4
-openttd-helpers==1.1.0
+openttd-helpers==1.2.0
 openttd-protocol==1.4.1
 pproxy==2.7.8
 requests==2.28.1


### PR DESCRIPTION
In many places in the code we use asyncio.create_task() in a fire&forget way, where we don't store the result value anywhere.

Sadly, this can lead to the GC removing the task before it is done executing. It doesn't seem to happen that often, but some traces on Sentry suggest it might be the cause of some of the trouble.