### PR TITLE
Fix: [Stun] check every 10s for a stale database connection

### DIFF
--- a/game_coordinator/application/stun.py
+++ b/game_coordinator/application/stun.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 log = logging.getLogger(__name__)
@@ -10,10 +11,28 @@ class Application:
         log.info("Starting STUN server ...")
 
     async def startup(self):
-        pass
+        asyncio.create_task(self._guard(self._check_database_connection()))
 
     async def shutdown(self):
         log.info("Shutting down STUN server ...")
+
+    async def _guard(self, coroutine):
+        try:
+            await coroutine
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("System co-routine failed, killing server ..")
+
+            import sys
+
+            sys.exit(1)
+
+    async def _check_database_connection(self):
+        # Check every 10 seconds if the database connection is still there.
+        while True:
+            await self.database.ping()
+            await asyncio.sleep(10)
 
     async def receive_PACKET_STUN_SERCLI_STUN(self, source, protocol_version, token, interface_number):
         await self.database.stun_result(token, interface_number, source.ip, source.port)

--- a/game_coordinator/database/redis.py
+++ b/game_coordinator/database/redis.py
@@ -333,6 +333,9 @@ class Database:
         await self._redis.delete(f"gc-server-newgrf:{server_id}")
         await self.add_to_stream("delete", {"server_id": server_id})
 
+    async def ping(self):
+        await self._redis.ping()
+
     async def stats_verify(self, connection_type_name):
         await self._stats("verify", connection_type_name)
 


### PR DESCRIPTION
Turn and coordinator already do this implicit. Stun now does it explicit.

All three applications crash when no redis connection can be made. This is deliberate, as often it requires a new DNS lookup for a connection to be established. As these services are meant to run in a container that auto-restarts, this will deal with that issue.