### PR TITLE
Add: on shutdown, keep the TURN server around till all clients disconnect

### DIFF
--- a/game_coordinator/__main__.py
+++ b/game_coordinator/__main__.py
@@ -47,7 +47,11 @@ async def close_server(loop, app_instance, server):
     await server.wait_closed()
 
     # Shut down the application, allowing it to do cleanup.
-    await app_instance.shutdown()
+    try:
+        await app_instance.shutdown()
+    except Exception:
+        log.exception("Error while shutting down application")
+        # Despite the exception, continue on with the shutdown.
 
     # Cancel all the remaining tasks and wait for them to have stopped.
     tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]


### PR DESCRIPTION
This means that if a SIGTERM is given, the TURN server will not shut down till all clients are gone. Of course there should be a deadline here, where the service is just killed. But that is up to the orchastrator to handle.