### PR TITLE
Update: aioredis merged with redis-py

### DIFF
--- a/game_coordinator/database/redis.py
+++ b/game_coordinator/database/redis.py
@@ -1,5 +1,4 @@
 import asyncio
-import aioredis
 import click
 import ipaddress
 import json
@@ -7,7 +6,8 @@ import logging
 import secrets
 import time
 
-from aioredis import ResponseError
+from redis import asyncio as aioredis
+from redis import ResponseError
 
 from openttd_helpers import click_helper
 

--- a/requirements.base
+++ b/requirements.base
@@ -1,5 +1,4 @@
 aiohttp
-aioredis
 click
 hiredis
 sentry-sdk
@@ -7,3 +6,4 @@ openttd-helpers
 openttd-protocol
 prometheus-client
 pproxy
+redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 aiohappyeyeballs==2.4.6
 aiohttp==3.11.12
-aioredis==2.0.1
 aiosignal==1.3.2
-async-timeout==5.0.1
 attrs==25.1.0
 certifi==2025.1.31
 click==8.1.8
@@ -15,7 +13,7 @@ openttd-protocol==1.7.1
 pproxy==2.7.9
 prometheus_client==0.21.1
 propcache==0.2.1
+redis==5.2.1
 sentry-sdk==2.21.0
-typing_extensions==4.12.2
 urllib3==2.3.0
 yarl==1.18.3


### PR DESCRIPTION
As it turns out, `aioredis` wasn't maintained anymore, and caused weird errors with Python 3.11. Upgrading to `redis-py` solves those issues. They claim it is a drop-in replacement.