### PR TITLE
Fix: hand-over the non-wrapped socket when using a SOCKS proxy

### DIFF
--- a/game_coordinator/application/helpers/token_verify.py
+++ b/game_coordinator/application/helpers/token_verify.py
@@ -169,7 +169,7 @@ class TokenVerify:
             sock = writer.transport.get_extra_info("socket")
             server = await asyncio.get_event_loop().create_connection(
                 lambda: GameProtocol(DetectGame(connected)),
-                sock=sock,
+                sock=sock._sock,  # Sneak in the actual socket, not the wrapped version.
             )
         else:
             server = await asyncio.get_event_loop().create_connection(


### PR DESCRIPTION
Basically, in Python 3.11 (possibly earlier), the `get_extra_info("socket")` returns a `TransportSocket`, which is a wrapper around the actual socket, preventing things like `send()` and `close()`. With Python 3.8 we got the raw socket back.

We can argue whether this PR is the correct solution or not, but I couldn't find a better way to hand over the socket from one socket handler to the other.

I understand that Python wants to protect people access the direct raw socket, but in this case that is exactly what I want. I am sure there is another way to solve this cleanly, but I also ran out of patient to solve this issue :)